### PR TITLE
Rel v4.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Releases 4.5.x are based on mainline support submitted in
 
 ## [Unreleased]
 
+## [v4.5.4] - 2017-02-23
+### Changed
+- adds new option tag when there isn't one in bootorder file
+- removed Serial console option - not used in mainline release
+- added Serial console redirection option - controls loading the sgabios oprom
+
 ## [v4.5.3] - 2017-01-12
 ### Fixed
 - bootorder file alignment

--- a/sortbootorder.c
+++ b/sortbootorder.c
@@ -56,7 +56,6 @@ static void update_tag_value(char buffer[MAX_DEVICES][MAX_LENGTH], u8 *max_lines
 
 /*** local variables ***/
 static u8 ipxe_toggle;
-static u8 serial_toggle;
 static u8 usb_toggle;
 static u8 sga_toggle;
 static char bootlist_def[MAX_DEVICES][MAX_LENGTH];
@@ -89,10 +88,7 @@ int main(void) {
 	u8 bootlist_map_ln = 0;
 	u8 line_start = 0;
 	u8 line_number = 0;
-	char *ipxe_str;
-	char *scon_str;
-	char *usb_str;
-	char *sga_str;
+	char *token;
 	struct cbfs_handle *bootorder_handle;
 
 	// Set to enabled because enable toggle is not (yet) implemented for these devices
@@ -119,21 +115,17 @@ int main(void) {
 	fetch_file_from_cbfs( BOOTORDER_MAP, bootlist_map, &bootlist_map_ln );
 
 	// Init ipxe and serial status
-	ipxe_str = cbfs_find_string("pxen", BOOTORDER_FILE);
-	ipxe_str += strlen("pxen");
-	ipxe_toggle = ipxe_str ? strtoul(ipxe_str, NULL, 10) : 1;
+	token = cbfs_find_string("pxen", BOOTORDER_FILE);
+	token += strlen("pxen");
+	ipxe_toggle = token ? strtoul(token, NULL, 10) : 1;
 
-	scon_str = cbfs_find_string("scon", BOOTORDER_FILE);
-	scon_str += strlen("scon");
-	serial_toggle = scon_str ? strtoul(scon_str, NULL, 10) : 1;
+	token = cbfs_find_string("usben", BOOTORDER_FILE);
+	token += strlen("usben");
+	usb_toggle = token ? strtoul(token, NULL, 10) : 1;
 
-	usb_str = cbfs_find_string("usben", BOOTORDER_FILE);
-	usb_str += strlen("usben");
-	usb_toggle = usb_str ? strtoul(usb_str, NULL, 10) : 1;
-
-	sga_str = cbfs_find_string("sgaen", BOOTORDER_FILE);
-	sga_str += strlen("sgaen");
-	sga_toggle = sga_str ? strtoul(sga_str, NULL, 10) : 0;
+	token = cbfs_find_string("sgaen", BOOTORDER_FILE);
+	token += strlen("sgaen");
+	sga_toggle = token ? strtoul(token, NULL, 10) : 0;
 
 	show_boot_device_list( bootlist, max_lines, bootlist_def_ln );
 	int_ids( bootlist, max_lines, bootlist_def_ln );
@@ -149,10 +141,6 @@ int main(void) {
 					copy_list_line(&(bootlist_def[i][0]), &(bootlist[i][0]));
 				int_ids( bootlist, max_lines, bootlist_def_ln );
 				break;
-			case 't':
-			case 'T':
-				serial_toggle ^= 0x1;
-				break;
 			case 'n':
 			case 'N':
 				ipxe_toggle ^= 0x1;
@@ -167,7 +155,6 @@ int main(void) {
 				break;
 			case 's':
 			case 'S':
-				update_tag_value(bootlist, &max_lines, "scon", serial_toggle + '0');
 				update_tag_value(bootlist, &max_lines, "pxen", ipxe_toggle + '0');
 				update_tag_value(bootlist, &max_lines, "usben", usb_toggle + '0');
 				update_tag_value(bootlist, &max_lines, "sgaen", sga_toggle + '0');
@@ -260,9 +247,8 @@ static void show_boot_device_list( char buffer[MAX_DEVICES][MAX_LENGTH], u8 line
 	printf("\n\n");
 	printf("  r Restore boot order defaults\n");
 	printf("  n Network/PXE boot - Currently %s\n", (ipxe_toggle) ? "Enabled" : "Disabled");
-	printf("  t Serial console - Currently %s\n", (serial_toggle) ? "Enabled" : "Disabled");
-	printf("  u USB boot - Currently %s\n", (usb_toggle) ? "Enabled" : "Disabled");
 	printf("  l Serial console redirection - Currently %s\n", (sga_toggle) ? "Enabled" : "Disabled");
+	printf("  u USB boot - Currently %s\n", (usb_toggle) ? "Enabled" : "Disabled");
 	printf("  x Exit setup without save\n");
 	printf("  s Save configuration and exit\n");
 }

--- a/version.h
+++ b/version.h
@@ -18,6 +18,6 @@
 #ifndef _VERSION_H_
 #define _VERSION_H_
 
-#define SORTBOOTORDER_VER "v4.5.3"
+#define SORTBOOTORDER_VER "v4.5.4"
 
 #endif /* _VERSION_H_ */


### PR DESCRIPTION
* add an option to enable/disable sgabios oprom loading (sgaen)
* remove scon option - not used in mainline
* update_tag_value() adds a tag to bootorder file if it doesn't exist