### PR TITLE
sortbootorder.c: allow to force CLK for mPCIe2 slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,14 @@ Change log for PC Engines sortbootorder
 
 Releases 4.0.x are based on PC Engines 20160304 release.
 
-Releases 4.5.x are based on mainline support submitted in
+Releases 4.5.x and 4.6.x are based on mainline support submitted in
 [this gerrit ref](https://review.coreboot.org/#/c/14138/).
 
 ## [Unreleased]
+
+## [v4.5.7] - 2017-07-21
+### Added
+- Add option to force CLK for mPCIe2 slot (GPP3 PCIe CLK)
 
 ## [v4.5.6] - 2017-06-29
 ### Added
@@ -102,7 +106,8 @@ initial commit based on [coreboot_140908](http://pcengines.ch/tmp/coreboot_14090
 ### Fixed
 - used proper way to access extended SPI registers
 
-[Unreleased]: https://github.com/pcengines/sortbootorder/compare/v4.5.6...master
+[Unreleased]: https://github.com/pcengines/sortbootorder/compare/v4.5.7...master
+[v4.5.6]: https://github.com/pcengines/sortbootorder/compare/v4.5.6...v4.5.7
 [v4.5.6]: https://github.com/pcengines/sortbootorder/compare/v4.5.5...v4.5.6
 [v4.5.5]: https://github.com/pcengines/sortbootorder/compare/v4.5.4...v4.5.5
 [v4.5.4]: https://github.com/pcengines/sortbootorder/compare/v4.5.3...v4.5.4

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ For coreboot legacy (4.0.x) version:
   t Serial console - Currently Enabled
   o UART C - Currently Enabled
   p UART D - Currently Enabled
+  m Force mPCIe2 slot CLK (GPP3 PCIe) - Currently Disabled
   h EHCI0 controller - Currently Disabled
   w Enable BIOS write protect - Currently Disabled
   x Exit setup without save
@@ -91,6 +92,11 @@ key.
      enabled GPIO.
 * `p UART D` - enables/disables UART D on GPIO header. Disabled UART means
      enabled GPIO.
+* `m Force mPCIe2 slot CLK (GPP3 PCIe)` - enabling this option forces GPP3 PCIe
+  clock (which is attached to mPCIe2 slot) to be always on. This helps in some
+  cases, one example could be
+  [mPCIe Ethernet extensioncard](https://github.com/pcengines/apu2-documentation/blob/master/docs/debug/mpcie_ethernet.md). It is advised
+  to set to `Disable` if co extension card is attached to mPCIe2 slot.
 * `h EHCI0 controller` - enables/disables EHCI0 controller (used in apu3)
 * `w Enable BIOS write protect` - enables/disables BIOS WP functionality. For
     details, see descritption in [BIOS WP option](#bios-wp-option).

--- a/README.md
+++ b/README.md
@@ -95,8 +95,9 @@ key.
 * `m Force mPCIe2 slot CLK (GPP3 PCIe)` - enabling this option forces GPP3 PCIe
   clock (which is attached to mPCIe2 slot) to be always on. This helps in some
   cases, one example could be
-  [mPCIe Ethernet extensioncard](https://github.com/pcengines/apu2-documentation/blob/master/docs/debug/mpcie_ethernet.md). It is advised
-  to set to `Disable` if co extension card is attached to mPCIe2 slot.
+  [mPCIe Ethernet extensioncard](https://github.com/pcengines/apu2-documentation/blob/master/docs/debug/mpcie_ethernet.md).
+  It is advised to set to `Disable` if no extension card is attached to mPCIe2
+  slot.
 * `h EHCI0 controller` - enables/disables EHCI0 controller (used in apu3)
 * `w Enable BIOS write protect` - enables/disables BIOS WP functionality. For
     details, see descritption in [BIOS WP option](#bios-wp-option).

--- a/sortbootorder.c
+++ b/sortbootorder.c
@@ -344,7 +344,7 @@ static void show_boot_device_list( char buffer[MAX_DEVICES][MAX_LENGTH], u8 line
 	printf("  t Serial console - Currently %s\n", (console_toggle) ? "Enabled" : "Disabled");
 	printf("  o UART C - Currently %s\n", (uartc_toggle) ? "Enabled" : "Disabled");
 	printf("  p UART D - Currently %s\n", (uartd_toggle) ? "Enabled" : "Disabled");
-	printf("  m Force mPCIe2 slot CLK - Currently %s\n", (mpcie2_clk_toggle) ? "Enabled" : "Disabled");
+	printf("  m Force mPCIe2 slot CLK (GPP3 PCIe) - Currently %s\n", (mpcie2_clk_toggle) ? "Enabled" : "Disabled");
 	printf("  h EHCI0 controller - Currently %s\n", (ehci0_toggle) ? "Enabled" : "Disabled");
 #endif
 	printf("  w Enable BIOS write protect - Currently %s\n", (spi_wp_toggle) ? "Enabled" : "Disabled");

--- a/sortbootorder.c
+++ b/sortbootorder.c
@@ -73,6 +73,7 @@ static u8 console_toggle;
 static u8 ehci0_toggle;
 static u8 uartc_toggle;
 static u8 uartd_toggle;
+static u8 mpcie2_clk_toggle;
 #endif
 
 static char bootlist_def[MAX_DEVICES][MAX_LENGTH];
@@ -171,6 +172,10 @@ int main(void) {
 	token = cbfs_find_string("uartd", BOOTORDER_FILE);
 	token += strlen("uartd");
 	uartd_toggle = token ? strtoul(token, NULL, 10) : 0;
+
+	token = cbfs_find_string("mpcie2_clk", BOOTORDER_FILE);
+	token += strlen("mpcie2_clk");
+	mpcie2_clk_toggle = token ? strtoul(token, NULL, 10) : 0;
 #endif
 
 	spi_wp_toggle = is_flash_locked();
@@ -223,6 +228,10 @@ int main(void) {
 			case 'P':
 				uartd_toggle ^= 0x1;
 				break;
+			case 'm':
+			case 'M':
+				mpcie2_clk_toggle ^= 0x1;
+				break;
 			case 'h':
 			case 'H':
 				ehci0_toggle ^= 0x1;
@@ -237,6 +246,7 @@ int main(void) {
 				update_tag_value(bootlist, &max_lines, "scon", console_toggle + '0');
 				update_tag_value(bootlist, &max_lines, "uartc", uartc_toggle + '0');
 				update_tag_value(bootlist, &max_lines, "uartd", uartd_toggle + '0');
+				update_tag_value(bootlist, &max_lines, "mpcie2_clk", mpcie2_clk_toggle + '0');
 				update_tag_value(bootlist, &max_lines, "ehcien", ehci0_toggle + '0');
 #endif
 				save_flash( bootlist, max_lines );
@@ -334,6 +344,7 @@ static void show_boot_device_list( char buffer[MAX_DEVICES][MAX_LENGTH], u8 line
 	printf("  t Serial console - Currently %s\n", (console_toggle) ? "Enabled" : "Disabled");
 	printf("  o UART C - Currently %s\n", (uartc_toggle) ? "Enabled" : "Disabled");
 	printf("  p UART D - Currently %s\n", (uartd_toggle) ? "Enabled" : "Disabled");
+	printf("  m Force mPCIe2 slot CLK - Currently %s\n", (mpcie2_clk_toggle) ? "Enabled" : "Disabled");
 	printf("  h EHCI0 controller - Currently %s\n", (ehci0_toggle) ? "Enabled" : "Disabled");
 #endif
 	printf("  w Enable BIOS write protect - Currently %s\n", (spi_wp_toggle) ? "Enabled" : "Disabled");

--- a/version.h
+++ b/version.h
@@ -18,6 +18,6 @@
 #ifndef _VERSION_H_
 #define _VERSION_H_
 
-#define SORTBOOTORDER_VER "v4.5.6"
+#define SORTBOOTORDER_VER "v4.5.7"
 
 #endif /* _VERSION_H_ */


### PR DESCRIPTION
Allow to force CLK to mPCIe2 slot. It makes sense only with legacy code - in mainline there are no bios_knobs anymore.