### PR TITLE
Apu1 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,10 @@ ifeq ($(SPI_DEBUG),1)
 	CFLAGS += -DSPI_DEBUG -DSPI_TRACE_ENABLED
 endif
 
+ifneq ($(APU1),y)
+	CFLAGS += -DFCH_YANGTZEE
+endif
+
 real-all: version $(TARGET)
 
 version:

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,9 @@ ifeq ($(SPI_DEBUG),1)
 	CFLAGS += -DSPI_DEBUG -DSPI_TRACE_ENABLED
 endif
 
-ifneq ($(APU1),y)
+ifeq ($(APU1),y)
+	CFLAGS += -DTARGET_APU1
+else
 	CFLAGS += -DFCH_YANGTZEE
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,10 @@ ifeq ($(COREBOOT_REL),legacy)
 	CFLAGS += -DCOREBOOT_LEGACY
 endif
 
+ifeq ($(SPI_DEBUG),1)
+	CFLAGS += -DSPI_DEBUG -DSPI_TRACE_ENABLED
+endif
+
 real-all: version $(TARGET)
 
 version:

--- a/sortbootorder.c
+++ b/sortbootorder.c
@@ -61,10 +61,17 @@ static u8 usb_toggle;
 static u8 spi_wp_toggle;
 
 static u8 console_toggle;
+
+#ifndef TARGET_APU1
 static u8 ehci0_toggle;
+#endif
+
 static u8 uartc_toggle;
 static u8 uartd_toggle;
+
+#ifndef TARGET_APU1
 static u8 mpcie2_clk_toggle;
+#endif
 
 static char bootlist_def[MAX_DEVICES][MAX_LENGTH];
 static char bootlist_map[MAX_DEVICES][MAX_LENGTH];
@@ -107,7 +114,11 @@ int main(void) {
 	noecho(); /* don't echo keystrokes */
 #endif
 
+#ifdef TARGET_APU1
+	printf("\n### PC Engines apu1 setup %s ###\n", SORTBOOTORDER_VER);
+#else
 	printf("\n### PC Engines apu2 setup %s ###\n", SORTBOOTORDER_VER);
+#endif
 
 	if (init_flash()) {
 		printf("Can't initialize flash device!\n");
@@ -145,9 +156,11 @@ int main(void) {
 	token += strlen("scon");
 	console_toggle = token ? strtoul(token, NULL, 10) : 1;
 
+#ifndef TARGET_APU1
 	token = cbfs_find_string("ehcien", BOOTORDER_FILE);
 	token += strlen("ehcien");
 	ehci0_toggle = token ? strtoul(token, NULL, 10) : 1;
+#endif
 
 	token = cbfs_find_string("uartc", BOOTORDER_FILE);
 	token += strlen("uartc");
@@ -157,10 +170,11 @@ int main(void) {
 	token += strlen("uartd");
 	uartd_toggle = token ? strtoul(token, NULL, 10) : 0;
 
+#ifndef TARGET_APU1
 	token = cbfs_find_string("mpcie2_clk", BOOTORDER_FILE);
 	token += strlen("mpcie2_clk");
 	mpcie2_clk_toggle = token ? strtoul(token, NULL, 10) : 0;
-
+#endif
 
 	spi_wp_toggle = is_flash_locked();
 
@@ -187,6 +201,7 @@ int main(void) {
 			case 'U':
 				usb_toggle ^= 0x1;
 				break;
+#ifndef TARGET_APU1
 			case 'w':
 			case 'W':
 				if (spi_wp_toggle) {
@@ -196,6 +211,7 @@ int main(void) {
 				}
 				spi_wp_toggle = is_flash_locked();
 				break;
+#endif
 			case 't':
 			case 'T':
 				console_toggle ^= 0x1;
@@ -208,6 +224,7 @@ int main(void) {
 			case 'P':
 				uartd_toggle ^= 0x1;
 				break;
+#ifndef TARGET_APU1
 			case 'm':
 			case 'M':
 				mpcie2_clk_toggle ^= 0x1;
@@ -219,6 +236,7 @@ int main(void) {
 			case 'Z':
 				handle_reg_sec_menu();
 				break;
+#endif
 			case 's':
 			case 'S':
 				update_tag_value(bootlist, &max_lines, "pxen", ipxe_toggle + '0');
@@ -226,8 +244,10 @@ int main(void) {
 				update_tag_value(bootlist, &max_lines, "scon", console_toggle + '0');
 				update_tag_value(bootlist, &max_lines, "uartc", uartc_toggle + '0');
 				update_tag_value(bootlist, &max_lines, "uartd", uartd_toggle + '0');
+#ifndef TARGET_APU1
 				update_tag_value(bootlist, &max_lines, "mpcie2_clk", mpcie2_clk_toggle + '0');
 				update_tag_value(bootlist, &max_lines, "ehcien", ehci0_toggle + '0');
+#endif
 				save_flash(flash_address, bootlist, max_lines, spi_wp_toggle);
 				// fall through to exit ...
 			case 'x':
@@ -323,9 +343,11 @@ static void show_boot_device_list( char buffer[MAX_DEVICES][MAX_LENGTH], u8 line
 	printf("  t Serial console - Currently %s\n", (console_toggle) ? "Enabled" : "Disabled");
 	printf("  o UART C - Currently %s\n", (uartc_toggle) ? "Enabled" : "Disabled");
 	printf("  p UART D - Currently %s\n", (uartd_toggle) ? "Enabled" : "Disabled");
+#ifndef TARGET_APU1
 	printf("  m Force mPCIe2 slot CLK (GPP3 PCIe) - Currently %s\n", (mpcie2_clk_toggle) ? "Enabled" : "Disabled");
 	printf("  h EHCI0 controller - Currently %s\n", (ehci0_toggle) ? "Enabled" : "Disabled");
 	printf("  w Enable BIOS write protect - Currently %s\n", (spi_wp_toggle) ? "Enabled" : "Disabled");
+#endif
 	printf("  x Exit setup without save\n");
 	printf("  s Save configuration and exit\n");
 }
@@ -463,12 +485,13 @@ static void refresh_tag_values(u8 max_lines)
 			token += strlen("scon");
 			console_toggle = strtoul(token, NULL, 10);
 		}
-
+#ifndef TARGET_APU1
 		token = strstr(&(bootlist_def[i][0]), "ehcien");
 		if(token) {
 			token += strlen("ehcien");
 			ehci0_toggle = strtoul(token, NULL, 10);
 		}
+#endif
 
 		token = strstr(&(bootlist_def[i][0]), "uartc");
 		if(token) {
@@ -481,11 +504,12 @@ static void refresh_tag_values(u8 max_lines)
 			token += strlen("uartd");
 			uartd_toggle = strtoul(token, NULL, 10);
 		}
-
+#ifndef TARGET_APU1
 		token = strstr(&(bootlist_def[i][0]), "mpcie2_clk");
 		if(token) {
 			token += strlen("mpcie2_clk");
 			mpcie2_clk_toggle = strtoul(token, NULL, 10);
 		}
+#endif
 	}
 }

--- a/sortbootorder.c
+++ b/sortbootorder.c
@@ -201,7 +201,6 @@ int main(void) {
 			case 'U':
 				usb_toggle ^= 0x1;
 				break;
-#ifndef TARGET_APU1
 			case 'w':
 			case 'W':
 				if (spi_wp_toggle) {
@@ -211,7 +210,6 @@ int main(void) {
 				}
 				spi_wp_toggle = is_flash_locked();
 				break;
-#endif
 			case 't':
 			case 'T':
 				console_toggle ^= 0x1;
@@ -346,8 +344,8 @@ static void show_boot_device_list( char buffer[MAX_DEVICES][MAX_LENGTH], u8 line
 #ifndef TARGET_APU1
 	printf("  m Force mPCIe2 slot CLK (GPP3 PCIe) - Currently %s\n", (mpcie2_clk_toggle) ? "Enabled" : "Disabled");
 	printf("  h EHCI0 controller - Currently %s\n", (ehci0_toggle) ? "Enabled" : "Disabled");
-	printf("  w Enable BIOS write protect - Currently %s\n", (spi_wp_toggle) ? "Enabled" : "Disabled");
 #endif
+	printf("  w Enable BIOS write protect - Currently %s\n", (spi_wp_toggle) ? "Enabled" : "Disabled");
 	printf("  x Exit setup without save\n");
 	printf("  s Save configuration and exit\n");
 }

--- a/spi/macronix.c
+++ b/spi/macronix.c
@@ -232,6 +232,15 @@ static int macronix_set_lock_flags(struct spi_flash *flash, int lock)
 		goto out;
 	}
 
+	spi_flash_cmd_wait_ready(flash, 100);
+
+	ret = spi_flash_cmd(flash->spi, CMD_MX25XX_WRDI, NULL, 0);
+	if (ret < 0) {
+		spi_debug("SF: Status register write disable failed\n");
+		goto out;
+	}
+
+	ret = spi_flash_cmd_wait_ready(flash, 100);
 out:
 	spi_release_bus(flash->spi);
 	return ret;

--- a/spi/macronix.c
+++ b/spi/macronix.c
@@ -205,6 +205,32 @@ static int macronix_is_locked(struct spi_flash *flash)
 	return 0;
 }
 
+static int macronix_sec_read(struct spi_flash *flash, u32 offset, size_t len, void *buf)
+{
+	// TODO
+	return 0;
+}
+
+static int macronix_sec_program(struct spi_flash *flash, u32 offset, size_t len, const void *buf)
+{
+	// TODO
+	return 0;
+}
+
+static int macronix_sec_sts(struct spi_flash *flash)
+{
+	// TODO
+	return 0;
+}
+
+static int macronix_sec_lock(struct spi_flash *flash, u8 reg)
+{
+	// TODO
+	return 0;
+}
+
+
+
 struct spi_flash *spi_flash_probe_macronix(struct spi_slave *spi, u8 *idcode)
 {
 	const struct macronix_spi_flash_params *params;
@@ -232,11 +258,19 @@ struct spi_flash *spi_flash_probe_macronix(struct spi_slave *spi, u8 *idcode)
 	mcx->params = params;
 	mcx->flash.spi = spi;
 	mcx->flash.name = params->name;
+	mcx->flash.write = macronix_write;
+	mcx->flash.spi_erase = macronix_erase;
+	/* The following are not yet implemented.
+	 * Implement to enable BIOS WP and Security Registers support.
+	 */
 	mcx->flash.lock = macronix_lock;
 	mcx->flash.unlock = macronix_unlock;
 	mcx->flash.is_locked = macronix_is_locked;
-	mcx->flash.write = macronix_write;
-	mcx->flash.spi_erase = macronix_erase;
+	mcx->flash.sec_sts = macronix_sec_sts;
+	mcx->flash.sec_read = macronix_sec_read;
+	mcx->flash.sec_prog = macronix_sec_program;
+	mcx->flash.sec_lock = macronix_sec_lock;
+
 #if CONFIG_SPI_FLASH_NO_FAST_READ
 	mcx->flash.read = spi_flash_cmd_read_slow;
 #else

--- a/spi/macronix.c
+++ b/spi/macronix.c
@@ -187,6 +187,24 @@ static int macronix_erase(struct spi_flash *flash, u32 offset, size_t len)
 	return spi_flash_cmd_erase(flash, CMD_MX25XX_SE, offset, len);
 }
 
+static int macronix_unlock(struct spi_flash *flash)
+{
+	// TODO
+	return 0;
+}
+
+static int macronix_lock(struct spi_flash *flash)
+{
+	// TODO
+	return 0;
+}
+
+static int macronix_is_locked(struct spi_flash *flash)
+{
+	// TODO
+	return 0;
+}
+
 struct spi_flash *spi_flash_probe_macronix(struct spi_slave *spi, u8 *idcode)
 {
 	const struct macronix_spi_flash_params *params;
@@ -214,7 +232,9 @@ struct spi_flash *spi_flash_probe_macronix(struct spi_slave *spi, u8 *idcode)
 	mcx->params = params;
 	mcx->flash.spi = spi;
 	mcx->flash.name = params->name;
-
+	mcx->flash.lock = macronix_lock;
+	mcx->flash.unlock = macronix_unlock;
+	mcx->flash.is_locked = macronix_is_locked;
 	mcx->flash.write = macronix_write;
 	mcx->flash.spi_erase = macronix_erase;
 #if CONFIG_SPI_FLASH_NO_FAST_READ

--- a/spi/spi.c
+++ b/spi/spi.c
@@ -18,6 +18,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
  */
+
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -37,6 +38,8 @@ static u32 spibar;
 //
 // Support for YANGTZEE FCH spi controller
 //
+
+// TODO: should be undefined for apu1
 #define FCH_YANGTZEE
 
 #ifdef SPI_TRACE_ENABLED
@@ -171,18 +174,33 @@ int spi_xfer(struct spi_slave *slave,
 //
 #else
 
+#define FIFO_SIZE_OLD		8
+
 static void reset_internal_fifo_pointer(void)
 {
 	do {
-		writeb(spibar + 2, readb(spibar + 2) | 0x10);
+		writeb(readb(spibar + 2) | 0x10, spibar + 2);
 	} while (readb(spibar + 0xD) & 0x7);
 }
 
 static void execute_command(void)
 {
-	writeb(spibar + 2, readb(spibar + 2) | 1);
+	writeb(readb(spibar + 2) | 1, spibar + 2);
 
 	while ((readb(spibar + 2) & 1) && (readb(spibar+3) & 0x80));
+}
+
+static int compare_internal_fifo_pointer(uint8_t want)
+{
+	uint8_t have = readb(spibar + 0xd) & 0x07;
+	want %= FIFO_SIZE_OLD;
+	if (have != want) {
+		spi_debug("AMD SPI FIFO pointer corruption! Pointer is %d, wanted %d\n", have, want);
+		return 1;
+	} else {
+		spi_debug("AMD SPI FIFO pointer is %d, wanted %d\n", have, want);
+		return 0;
+	}
 }
 
 int spi_xfer(struct spi_slave *slave, const void *dout,
@@ -195,34 +213,52 @@ int spi_xfer(struct spi_slave *slave, const void *dout,
 	u8 bytesout, bytesin;
 	u8 count;
 
-	bitsout -= 8;
+	writeb(cmd, spibar + 0);
+
 	bytesout = bitsout / 8;
 	bytesin  = bitsin / 8;
+
+	bytesout--;
 
 	readoffby1 = bytesout ? 0 : 1;
 
 	readwrite = (bytesin + readoffby1) << 4 | bytesout;
-	writeb(spibar + 1, readwrite);
-	writeb(spibar + 0, cmd);
+	writeb(readwrite, spibar + 1);
 
 	reset_internal_fifo_pointer();
 	for (count = 0; count < bytesout; count++, dout++) {
-		writeb(spibar + 0x0C, *(u32 *)dout);
+		writeb(*(u32 *)dout, spibar + 0x0C);
 	}
+	if (compare_internal_fifo_pointer(bytesout))
+		return -1;
 
 	reset_internal_fifo_pointer();
 	execute_command();
 
+	if (compare_internal_fifo_pointer(bytesout + bytesin))
+		return -1;
+
 	reset_internal_fifo_pointer();
 	/* Skip the bytes we sent. */
 	for (count = 0; count < bytesout; count++) {
-		cmd = readb(spibar + 0x0C);
+		readb(spibar + 0x0C);
 	}
+
+	if (compare_internal_fifo_pointer(bytesout))
+		return -1;
 
 	//reset_internal_fifo_pointer();
 	for (count = 0; count < bytesin; count++, din++) {
 		*(u8 *)din = readb(spibar + 0x0C);
 	}
+
+	if (compare_internal_fifo_pointer(bytesout + bytesin))
+		return -1;
+
+	if(readb(spibar + 1) != readwrite)
+		return -1;
+
+	return 0;
 }
 #endif
 
@@ -230,6 +266,7 @@ void spi_init(void)
 {
     pcidev_t dev  = PCI_DEV(0,0x14,3);
     spibar = pci_read_config32(dev, 0xA0) & ~0x1F;
+    spi_debug("SF: spibar %x\n", spibar);
 }
 
 #if defined (CONFIG_SB800_IMC_FWM)

--- a/spi/spi.c
+++ b/spi/spi.c
@@ -39,9 +39,6 @@ static u32 spibar;
 // Support for YANGTZEE FCH spi controller
 //
 
-// TODO: should be undefined for apu1
-#define FCH_YANGTZEE
-
 #ifdef SPI_TRACE_ENABLED
     #define SPI_TRACE(...) printf( __VA_ARGS__);
 #else
@@ -266,7 +263,6 @@ void spi_init(void)
 {
     pcidev_t dev  = PCI_DEV(0,0x14,3);
     spibar = pci_read_config32(dev, 0xA0) & ~0x1F;
-    spi_debug("SF: spibar %x\n", spibar);
 }
 
 #if defined (CONFIG_SB800_IMC_FWM)


### PR DESCRIPTION
All features were checked and are working. mPCIe2 CLK is not utilized on apu1, as well as ehci0 (both are apu2 and its variants specific).